### PR TITLE
Fix: 로그아웃이 랜더링 되지 않던것을 해결하기 위한 제약조건 재설정

### DIFF
--- a/lib/src/feature/auth/ui/views/logout_button_view.dart
+++ b/lib/src/feature/auth/ui/views/logout_button_view.dart
@@ -1,5 +1,6 @@
 import 'package:a_and_i_report_web_server/src/feature/auth/ui/viewModels/auth_event.dart';
 import 'package:a_and_i_report_web_server/src/feature/auth/ui/viewModels/auth_view_model.dart';
+import 'package:a_and_i_report_web_server/src/feature/auth/ui/viewModels/auth_state.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
@@ -8,20 +9,41 @@ class LogoutButtonView extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final authViewModel = ref.read(authViewModelProvider.notifier);
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 8.0),
-      child: InkWell(
-        onTap: () async {
-          /// 버튼 탭시
-          /// 로그아웃됨
-          authViewModel.onEvent(SignOut());
-        },
-        child: Icon(
-          Icons.exit_to_app,
-          color: Color(0xffff0000),
-        ),
-      ),
+    final authStateAsync = ref.watch(authViewModelProvider);
+
+    return authStateAsync.when(
+      data: (authState) {
+        if (authState is Authenticated) {
+          final authViewModel = ref.read(authViewModelProvider.notifier);
+          return Container(
+            constraints: BoxConstraints(
+              minWidth: 48,
+              minHeight: 48,
+              maxWidth: 56,
+              maxHeight: 56,
+            ),
+            child: IconButton(
+              onPressed: () async {
+                /// 버튼 탭시
+                /// 로그아웃됨
+                await authViewModel.onEvent(SignOut());
+              },
+              icon: Icon(
+                Icons.exit_to_app,
+                color: Color(0xffff0000),
+                size: 24,
+              ),
+              tooltip: '로그아웃',
+              padding: EdgeInsets.all(8),
+            ),
+          );
+        } else {
+          // 인증되지 않은 상태에서는 빈 컨테이너 반환
+          return SizedBox.shrink();
+        }
+      },
+      loading: () => SizedBox.shrink(), // 로딩 중에는 빈 공간
+      error: (_, __) => SizedBox.shrink(), // 에러 시에도 빈 공간
     );
   }
 }

--- a/lib/src/feature/home/ui/views/home_ui.dart
+++ b/lib/src/feature/home/ui/views/home_ui.dart
@@ -10,28 +10,41 @@ class HomeUI extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      extendBodyBehindAppBar: true,
       appBar: AppBar(
         elevation: 0,
         backgroundColor: Colors.transparent,
         actions: [LogoutButtonView()],
+        toolbarHeight: 56,
       ),
       body: SingleChildScrollView(
         child: ResponsiveLayout(
             mobile: Padding(
-              padding: EdgeInsets.symmetric(
-                vertical: 10,
-                horizontal: 20,
+              padding: EdgeInsets.only(
+                top: MediaQuery.of(context).padding.top +
+                    66, // status bar + app bar + extra
+                left: 20,
+                right: 20,
+                bottom: 10,
               ),
               child: HomeMobileScreen(),
             ),
             tablet: Padding(
-              padding:
-                  EdgeInsets.only(right: 100, left: 100, top: 100, bottom: 15),
+              padding: EdgeInsets.only(
+                top: MediaQuery.of(context).padding.top + 76,
+                right: 100,
+                left: 100,
+                bottom: 15,
+              ),
               child: HomeScreen(),
             ),
             desktop: Padding(
-              padding:
-                  EdgeInsets.only(right: 200, left: 200, top: 100, bottom: 15),
+              padding: EdgeInsets.only(
+                top: MediaQuery.of(context).padding.top + 76,
+                right: 200,
+                left: 200,
+                bottom: 15,
+              ),
               child: HomeScreen(),
             )),
       ),


### PR DESCRIPTION
로그아웃 버튼의 PIXEL OVERFLOW 현상을 방지하기 위한 제약조건이 재설정 되었습니다.